### PR TITLE
Fix GNU screen issues running under Ruby PTY. Closes #2

### DIFF
--- a/lib/screenxtv.rb
+++ b/lib/screenxtv.rb
@@ -168,7 +168,6 @@ Thread.new{
 }
 
 begin
-  system "stty raw"
   master,slave=PTY.open
   ENV['TERM']='vt100'
   ENV['LANG']='en_US.UTF-8'
@@ -193,7 +192,7 @@ begin
   Signal.trap(:SIGCHLD){stop "broadcast end"}
   Thread.new{
     loop do
-      master.write STDIN.getc
+      master.write STDIN.getch
     end
   }
   while(data=master.readpartial 1024)


### PR DESCRIPTION
`STDIN.getch` was introduced in Ruby 1.9.3, and solves the problem of having to press enter after issuing a screen command, such as switching tabs.

Removing `stty raw` prevents the double echoing of characters typed.

This should be verified by one of you on OS X before merging. 
