### PR TITLE
avoid ruby io.winsize= bug

### DIFF
--- a/lib/screenxtv.rb
+++ b/lib/screenxtv.rb
@@ -330,10 +330,10 @@ Thread.new{
 
 begin
   ENV['LANG']='en_US.UTF-8'
-  
+
   PTY::getpty *exec_cmd do |rr,ww|
     winsize=->{
-      height,width=ww.winsize=rr.winsize=STDOUT.winsize
+      height,width=ww.winsize=rr.winsize=[*STDOUT.winsize.take(2),nil,nil]
       socket.send 'winch',{width:width,height:height}.to_json
     }
     winsize.call


### PR DESCRIPTION
```ruby
STDIN.winsize=[1,2,3,4,5] #=> wrong number of arguments (given 1, expected 2..4)
STDIN.winsize=[80,24,123,456] #=> ok
STDIN.winsize=[80,24,123] #=> ok
STDIN.winsize=[80,24] #=> TypeError: no implicit conversion of false into Integer
STDIN.winsize=[80,24,nil,nil] #=> ok
```

avoid the above bug by
```ruby
STDIN.winsize=[*size,nil,nil]
```